### PR TITLE
Fixed width/height of ReflexilHost

### DIFF
--- a/Plugins/Reflexil.ILSpy/Plugins/ReflexilHost.xaml.cs
+++ b/Plugins/Reflexil.ILSpy/Plugins/ReflexilHost.xaml.cs
@@ -21,6 +21,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 using System.Windows;
 using System.Windows.Forms.Integration;
+using System.Windows.Interop;
+using System.Windows.Media;
 using Panel = System.Windows.Forms.Panel;
 
 namespace Reflexil.Plugins.ILSpy
@@ -44,8 +46,26 @@ namespace Reflexil.Plugins.ILSpy
 
 		private void OnRootSizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			_package.ReflexilWindow.Width = (int) Root.ActualWidth;
-			_package.ReflexilWindow.Height = (int) Root.ActualHeight;
+			CompositionTarget ct = GetCompositionTarget(Root);
+			Vector dips = new Vector(Root.ActualWidth, Root.ActualHeight);
+			Vector pixels = ct.TransformToDevice.Transform(dips);
+
+			_package.ReflexilWindow.Width = (int)pixels.X;
+			_package.ReflexilWindow.Height = (int)pixels.Y;
+		}
+
+		static CompositionTarget GetCompositionTarget(Visual control)
+		{
+			// check if the visual is attached to source
+			{
+				PresentationSource source = PresentationSource.FromVisual(control);
+				if (source != null)
+					return source.CompositionTarget;
+			}
+
+			// create new source
+			using (HwndSource source = new HwndSource(new HwndSourceParameters()))
+				return source.CompositionTarget;
 		}
 	}
 }


### PR DESCRIPTION
`ActualWidth/Height` are measured in device-independent units, which are not equals to pixels in some cases, and need to be converted.