### PR TITLE
Added copy/paste to instruction editing grid

### DIFF
--- a/Controls/Grid/InstructionGridControl.Designer.cs
+++ b/Controls/Grid/InstructionGridControl.Designer.cs
@@ -35,6 +35,8 @@ namespace Reflexil.Editors
             this.OperandDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.MenReplaceNop = new System.Windows.Forms.ToolStripMenuItem();
 			this.MenReplaceBody = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenCopy = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenPaste = new System.Windows.Forms.ToolStripMenuItem();
 
             this.Grid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.OffsetDataGridViewTextBoxColumn,
@@ -45,10 +47,12 @@ namespace Reflexil.Editors
             // 
             GridContextMenuStrip.Items.Insert(GridContextMenuStrip.Items.IndexOf(MenSeparator), MenReplaceBody);
 			GridContextMenuStrip.Items.Insert(GridContextMenuStrip.Items.IndexOf(MenReplaceBody), MenReplaceNop);
-			// 
-			// MenReplaceBody
-			// 
-			this.MenReplaceBody.Name = "MenReplaceBody";
+            GridContextMenuStrip.Items.Insert(GridContextMenuStrip.Items.IndexOf(MenReplaceNop), MenPaste);
+            GridContextMenuStrip.Items.Insert(GridContextMenuStrip.Items.IndexOf(MenPaste), MenCopy);
+            // 
+            // MenReplaceBody
+            // 
+            this.MenReplaceBody.Name = "MenReplaceBody";
             this.MenReplaceBody.Size = new System.Drawing.Size(197, 22);
             this.MenReplaceBody.Text = "Replace all with code...";
             this.MenReplaceBody.Click += new System.EventHandler(this.MenReplaceBody_Click);
@@ -59,10 +63,24 @@ namespace Reflexil.Editors
 			this.MenReplaceNop.Size = new System.Drawing.Size(197, 22);
 			this.MenReplaceNop.Text = "Replace with NOP";
 			this.MenReplaceNop.Click += new System.EventHandler(this.MenReplaceNop_Click);
-			// 
-			// OffsetDataGridViewTextBoxColumn
-			// 
-			this.OffsetDataGridViewTextBoxColumn.DataPropertyName = "Offset";
+            ///
+            /// MenCopy
+            /// 
+            this.MenCopy.Name = "MenCopy";
+            this.MenCopy.Size = new System.Drawing.Size(197, 22);
+            this.MenCopy.Text = "Copy";
+            this.MenCopy.Click += new System.EventHandler(this.MenCopy_Click);
+            ///
+            /// MenPaste
+            /// 
+            this.MenPaste.Name = "MenPaste";
+            this.MenPaste.Size = new System.Drawing.Size(197, 22);
+            this.MenPaste.Text = "Paste after";
+            this.MenPaste.Click += new System.EventHandler(this.MenPaste_Click);
+            // 
+            // OffsetDataGridViewTextBoxColumn
+            // 
+            this.OffsetDataGridViewTextBoxColumn.DataPropertyName = "Offset";
             this.OffsetDataGridViewTextBoxColumn.HeaderText = "Offset";
             this.OffsetDataGridViewTextBoxColumn.Name = "OffsetDataGridViewTextBoxColumn";
             this.OffsetDataGridViewTextBoxColumn.ReadOnly = true;
@@ -94,7 +112,9 @@ namespace Reflexil.Editors
         internal System.Windows.Forms.DataGridViewTextBoxColumn OperandDataGridViewTextBoxColumn;
         private System.Windows.Forms.ToolStripMenuItem MenReplaceBody;
 		private System.Windows.Forms.ToolStripMenuItem MenReplaceNop;
+        private System.Windows.Forms.ToolStripMenuItem MenCopy;
+        private System.Windows.Forms.ToolStripMenuItem MenPaste;
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Controls/Grid/InstructionGridControl.cs
+++ b/Controls/Grid/InstructionGridControl.cs
@@ -22,6 +22,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #region Imports
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -34,11 +36,14 @@ namespace Reflexil.Editors
 {
 	public partial class InstructionGridControl : BaseInstructionGridControl
 	{
-		#region Methods
+	    
+
+	    #region Methods
 
 		public InstructionGridControl()
 		{
 			InitializeComponent();
+            _copiedItems = new List<Instruction>();
 		}
 
 		protected override void GridContextMenuStrip_Opened(object sender, EventArgs e)
@@ -48,6 +53,9 @@ namespace Reflexil.Editors
 			MenReplaceBody.Enabled = (!ReadOnly) && (OwnerDefinition != null) && (OwnerDefinition.Body != null);
 			MenDelete.Enabled = (!ReadOnly) && (SelectedItems.Length > 0);
 			MenDeleteAll.Enabled = (!ReadOnly) && (OwnerDefinition != null) && (OwnerDefinition.Body != null);
+
+		    MenCopy.Enabled = (!ReadOnly) && (SelectedItems.Length > 0);
+		    MenPaste.Enabled = (!ReadOnly) && (FirstSelectedItem != null) && (_copiedItems.Count > 0);
 		}
 
 		protected override void MenCreate_Click(object sender, EventArgs e)
@@ -157,6 +165,27 @@ namespace Reflexil.Editors
 			}
 			RaiseGridUpdated();
 		}
+
+	    private readonly List<Instruction> _copiedItems;
+
+	    private void MenCopy_Click(object sender, EventArgs e)
+	    {
+            _copiedItems.Clear();
+            foreach (var item in SelectedItems)
+	        {
+	            _copiedItems.Add(item);
+	        }
+	    }
+
+	    private void MenPaste_Click(object sender, EventArgs e)
+	    {
+	        foreach (var item in _copiedItems)
+	        {
+                var copy = new Instruction(item.OpCode, item.Operand);
+	            OwnerDefinition.Body.GetILProcessor().InsertAfter(FirstSelectedItem, copy);
+	        }
+            RaiseGridUpdated();
+        }
 
 		#endregion
 	}


### PR DESCRIPTION
I added copy/paste to the contextmenu of the instruction editor grid. I found this useful when editing the  instructions of bigger functions. (Copy/Paste first and then edit some instructions)