### PR TITLE
Add extra registry search keys to find tools on brand new install.

### DIFF
--- a/Utils/SdkUtility.cs
+++ b/Utils/SdkUtility.cs
@@ -49,8 +49,10 @@ namespace Reflexil.Utils
 			{@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A", "InstallationFolder"},
 			{@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A", "InstallationFolder"},
 			{@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A", "InstallationFolder"},
-			{@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1A", "InstallationFolder"}
-		};
+			{@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1A", "InstallationFolder"},
+			{@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v8.1A\WinSDK-NetFx40Tools", "InstallationFolder" },
+			{@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\NETFXSDK\4.6\WinSDK-NetFx40Tools", "InstallationFolder" }
+        };
 
 		private const string SdkBinPath = "Bin";
 
@@ -87,10 +89,12 @@ namespace Reflexil.Utils
 				if (executable == null)
 					return null;
 
-				executable = Path.Combine(PreparePath(executable), SdkBinPath);
-				if (!Directory.Exists(executable))
-					return null;
-			}
+				string executableBinDir = Path.Combine(PreparePath(executable), SdkBinPath);
+				if (Directory.Exists(executableBinDir))
+				{
+					executable = executableBinDir;
+				}
+            }
 			catch (Exception)
 			{
 				return null;


### PR DESCRIPTION
Make the appending of SDKBinPath optional as this will not work with files
found using the NET FX Tools path.

Needed this on my brand new install dev computer otherwise ILSpy/Reflexil was complaining it could not find the SDK tools that were installed. (New windows 10 install with only VS 2015)